### PR TITLE
image-surface-get-data unknown format bug fix

### DIFF
--- a/src/surface.lisp
+++ b/src/surface.lisp
@@ -152,9 +152,9 @@
 
 (defun get-bytes-per-pixel (format)
   (case format
-    (format-argb32 4)
-    (format-rgb24 3)
-    (format-a8 1)
+    (:argb32 4)
+    (:rgb24 3)
+    (:a8 1)
     (otherwise (error (format nil "unknown format: ~a" format))))) ;todo: how does format-a1 fit in here?
 
 (defun image-surface-get-data (surface &key (pointer-only nil))


### PR DESCRIPTION
image-surface-get-data calls get-bytes-per-pixel, which returns an "unknown format" error for any format. The symbols in the get-bytes-per-pixel code were wrong (format-argb32, format-rgb24, etc.) Replaced the undefined symbols with :argb32 :rgb24 and :a8 to fix the problem.
