### PR TITLE
image-surface-get-data/get-bytes-per-pixel fix 

### DIFF
--- a/src/surface.lisp
+++ b/src/surface.lisp
@@ -89,7 +89,7 @@
     (lookup-cairo-enum (cairo_surface_status (get-pointer surface)) table-status)))
 
 
-(defun new-surface-with-check (pointer width height &optional (pixel-based-p nil))
+ (defun new-surface-with-check (pointer width height &optional (pixel-based-p nil))
   "Check if the creation of new surface was successful, if so, return new class."
   (let ((surface (make-instance 'surface :width width :height height
 				:pixel-based-p pixel-based-p)))
@@ -153,7 +153,7 @@
 (defun get-bytes-per-pixel (format)
   (case format
     (:argb32 4)
-    (:rgb24 3)
+    (:rgb24 4)
     (:a8 1)
     (otherwise (error (format nil "unknown format: ~a" format))))) ;todo: how does format-a1 fit in here?
 


### PR DESCRIPTION
Previously, get-bytes-per-pixel was returning three for RGB24 formats.
However, the Cairo documentation states that RGB24 formats have 32 bits
per pixel. This means that image-surface-get-data was not returning all
of the data for RGB24 formats. Fixed so that now get-bytes-per-pixel
returns four for RGB24 formats.
