### PR TITLE
Added helper macros.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -23,7 +23,8 @@
    image-surface-get-stride image-surface-create-from-png
    image-surface-create-from-png-callback
    image-surface-create-from-png-stream
-   surface-write-to-png with-png-surface
+   with-context-from-surface with-surface-and-context
+   surface-write-to-png with-surface with-png-surface
    create-surface-from-foreign
    surface-flush surface-finish surface-mark-dirty
 

--- a/src/surface.lisp
+++ b/src/surface.lisp
@@ -309,6 +309,31 @@ Otherwise, return the copy of the image data along with the pointer."
   (with-cairo-object (surface pointer)
 	(cairo_image_surface_get_stride pointer)))
 
+(defmacro with-surface ((surface &optional surface-name) &body body)
+  (let ((var-name (or surface-name '*surface*)))
+    `(let ((,var-name ,surface))
+       (unwind-protect
+	    (progn ,@body)
+       
+	 (progn (surface-finish ,var-name)
+		(destroy ,var-name))))))
+
+(defmacro with-context-from-surface ((surface) &body body)
+  (let ((context (gensym "context")))
+    `(let ((,context (create-context ,surface)))
+       (unwind-protect
+	    (with-context (,context)
+	      ,@body)	      
+	 (destroy ,context)))))
+
+
+(defmacro with-surface-and-context ((surface &optional surface-name) &body body)
+  (let ((var-name (or surface-name '*surface*)))
+    `(with-surface (,surface ,var-name)
+       (with-context-from-surface (,var-name)
+	 ,@body))))
+
+
 ;;;;
 ;;;;  PNG surfaces
 ;;;;
@@ -372,7 +397,7 @@ single argument which is the amount of data that to be retrieved."
                        pointer (namestring (merge-pathnames filename)))))
 	  (unless (eq (lookup-cairo-enum status table-status) :success)
 		(warn "function returned with status ~a." status)))))
-
+    
 (defmacro with-png-surface ((png-file surface-name) &body body)
   `(let ((,surface-name (image-surface-create-from-png ,png-file)))
 	 (unwind-protect (progn ,@body)


### PR DESCRIPTION
I added with-surface, with-context-from-surface and with-surface-and-context macros which I use to make life easier with cl-pango. cl-pango was a part of clinch, but I'm moving it away so it's useful to other libraries. I've used these macros in clinch and they help prevent errors when transient creating surfaces.

Currently I export these symbols through cl-pango in an (in-package ..) and (export ...). This shouldn't be an issue considering it's an experimental library. 